### PR TITLE
corrected bug that prevent rspec to be green at first launch

### DIFF
--- a/spec/support/helpers/session_helpers.rb
+++ b/spec/support/helpers/session_helpers.rb
@@ -12,7 +12,7 @@ module Features
       visit new_user_session_path
       fill_in 'Email', with: email
       fill_in 'Password', with: password
-      click_button 'Sign in'
+      click_button 'Log in'
     end
   end
 end


### PR DESCRIPTION
User has to click on 'Log in' and not 'Sign in' in order to enter the session, thus causing rspec error