### PR TITLE
Changed Heroku recommendation from Unicorn to Puma

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -202,7 +202,7 @@ The application generator template will ask you for additional preferences:
 
 h4. Web Servers
 
-If you plan to deploy to Heroku, select Unicorn as your production webserver. Unicorn is recommended by Heroku.
+If you plan to deploy to Heroku, select Puma as your production webserver. Puma is recommended by Heroku.
 
 h4. Database
 


### PR DESCRIPTION
Heroku now recommends Puma.

> Heroku recommends using the Puma web server instead of Unicorn. If you are using Unicorn, your application is not protected against a slow client attack.
https://devcenter.heroku.com/articles/rails-unicorn Last Updated: Feb 01, 2016