### PR TITLE
Rspec tests: changed to allow error message match

### DIFF
--- a/spec/features/users/sign_in_spec.rb
+++ b/spec/features/users/sign_in_spec.rb
@@ -10,7 +10,7 @@ feature 'Sign in', :devise do
   #   Then I see an invalid credentials message
   scenario 'user cannot sign in if not registered' do
     signin('test@example.com', 'please123')
-    expect(page).to have_content I18n.t 'devise.failure.not_found_in_database', authentication_keys: 'email'
+    expect(page).to have_content I18n.t 'devise.failure.not_found_in_database', authentication_keys: 'Email'
   end
 
   # Scenario: User can sign in with valid credentials
@@ -32,7 +32,7 @@ feature 'Sign in', :devise do
   scenario 'user cannot sign in with wrong email' do
     user = FactoryGirl.create(:user)
     signin('invalid@email.com', user.password)
-    expect(page).to have_content I18n.t 'devise.failure.not_found_in_database', authentication_keys: 'email'
+    expect(page).to have_content I18n.t 'devise.failure.not_found_in_database', authentication_keys: 'Email'
   end
 
   # Scenario: User cannot sign in with wrong password
@@ -43,7 +43,7 @@ feature 'Sign in', :devise do
   scenario 'user cannot sign in with wrong password' do
     user = FactoryGirl.create(:user)
     signin(user.email, 'invalidpass')
-    expect(page).to have_content I18n.t 'devise.failure.invalid', authentication_keys: 'email'
+    expect(page).to have_content I18n.t 'devise.failure.invalid', authentication_keys: 'Email'
   end
 
 end

--- a/spec/features/visitors/sign_up_spec.rb
+++ b/spec/features/visitors/sign_up_spec.rb
@@ -37,7 +37,7 @@ feature 'Sign Up', :devise do
   #   When I sign up with a short password
   #   Then I see a 'too short password' message
   scenario 'visitor cannot sign up with a short password' do
-    sign_up_with('test@example.com', 'please', 'please')
+    sign_up_with('test@example.com', 'test', 'test')
     expect(page).to have_content "Password is too short"
   end
 


### PR DESCRIPTION
@DanielKehoe, for some reason the Devise error messages were no longer matching.

ref: [Stackoverflow post](https://stackoverflow.com/questions/38857715/rails-4-devise-sign-in-specs-failing)

ref: https://github.com/RailsApps/rails-devise-pundit/issues/40